### PR TITLE
Add event bug

### DIFF
--- a/client/src/components/calendar/CalenderUtils.tsx
+++ b/client/src/components/calendar/CalenderUtils.tsx
@@ -1,0 +1,32 @@
+import { customAppointment, Event, FormProps } from '../../types/interfaces';
+
+const usaTime = (date: any) =>
+  new Date(date).toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
+
+export const mapEventToAppointment = (
+  googleEvent: Event
+): customAppointment => ({
+  id: googleEvent.id,
+  startDate: usaTime(googleEvent.start.dateTime),
+  endDate: usaTime(googleEvent.end.dateTime),
+  title: googleEvent.summary,
+  location: googleEvent.location,
+  description: googleEvent.description,
+  attendees: googleEvent.attendees,
+  readOnly: true,
+});
+
+export const mapAppointmentToEvent = (
+  appointment: customAppointment
+): Event => ({
+  location: appointment.location,
+  summary: appointment.title,
+  description: appointment.description,
+  start: {
+    dateTime: new Date(appointment.startDate),
+  },
+  end: {
+    dateTime: new Date(appointment.endDate),
+  },
+  attendees: appointment.attendees,
+});

--- a/client/src/components/calendar/InviteeCalender.tsx
+++ b/client/src/components/calendar/InviteeCalender.tsx
@@ -28,6 +28,7 @@ import { InviteeCalendarProps } from '../../types/interfaces';
 import ListGroup from 'react-bootstrap/ListGroup';
 import axios from 'axios';
 import { customAppointment, Event, FormProps } from '../../types/interfaces';
+import { mapEventToAppointment, mapAppointmentToEvent } from './CalenderUtils';
 const messages = {
   moreInformationLabel: '',
 };
@@ -224,38 +225,11 @@ const editEvent = (
   });
 };
 
-const usaTime = (date: any) =>
-  new Date(date).toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
-
 /**
  * mapAPpointmentData takes a list of appointments from google and maps them
  * to the data structure used by the schedular.
  * @param appointment
  */
-const mapEventToAppointment = (googleEvent: Event): customAppointment => ({
-  id: googleEvent.id,
-  startDate: usaTime(googleEvent.start.dateTime),
-  endDate: usaTime(googleEvent.end.dateTime),
-  title: googleEvent.summary,
-  location: googleEvent.location,
-  description: googleEvent.description,
-  attendees: googleEvent.attendees,
-  readOnly: true,
-});
-
-const mapAppointmentToEvent = (appointment: customAppointment): Event => ({
-  id: appointment.id,
-  location: appointment.location,
-  summary: appointment.title,
-  description: appointment.description,
-  start: {
-    dateTime: new Date(appointment.startDate),
-  },
-  end: {
-    dateTime: new Date(appointment.endDate),
-  },
-  attendees: appointment.attendees,
-});
 
 const initialState = {
   data: [],

--- a/client/src/components/calendar/SyncedCalender.tsx
+++ b/client/src/components/calendar/SyncedCalender.tsx
@@ -28,7 +28,8 @@ import { SyncedCalendarProps } from '../../types/interfaces';
 import ListGroup from 'react-bootstrap/ListGroup';
 import axios from 'axios';
 import { customAppointment, Event, FormProps } from '../../types/interfaces';
-import { Description } from '@material-ui/icons';
+import { mapEventToAppointment, mapAppointmentToEvent } from './CalenderUtils';
+
 const messages = {
   moreInformationLabel: '',
 };
@@ -182,38 +183,6 @@ const editEvent = (
     setTimeout(() => {}, timeout);
   });
 };
-
-const usaTime = (date: any) =>
-  new Date(date).toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
-
-/**
- * mapAPpointmentData takes a list of appointments from google and maps them
- * to the data structure used by the schedular.
- * @param appointment
- */
-const mapEventToAppointment = (googleEvent: Event): customAppointment => ({
-  id: googleEvent.id,
-  startDate: usaTime(googleEvent.start.dateTime),
-  endDate: usaTime(googleEvent.end.dateTime),
-  title: googleEvent.summary,
-  location: googleEvent.location,
-  description: googleEvent.description,
-  attendees: googleEvent.attendees,
-});
-
-const mapAppointmentToEvent = (appointment: customAppointment): Event => ({
-  id: appointment.id,
-  location: appointment.location,
-  summary: appointment.title,
-  description: appointment.description,
-  start: {
-    dateTime: new Date(appointment.startDate),
-  },
-  end: {
-    dateTime: new Date(appointment.endDate),
-  },
-  attendees: appointment.attendees,
-});
 
 const initialState = {
   data: [],

--- a/client/src/types/interfaces.ts
+++ b/client/src/types/interfaces.ts
@@ -135,7 +135,7 @@ interface Attendee {
 
 }
 export interface Event {
-  id: string;
+  id?: string;
   location: string;
   summary: string;
   description: string;
@@ -157,7 +157,7 @@ export interface customAppointment {
   endDate:SchedulerDateTime
   title: string;
   allDay?:boolean
-  id: string;
+  id?: string;
   rRule?:string;
   exDate?: string;
   readOnly?: boolean;


### PR DESCRIPTION
-api request for adding events to the calendar  no longer return an error.
-Issue was result of new events all having same ID, google calendar api requires events to have unique ID's in order to add them to the calendar. 
-Issue resolved by assigning each event added to calendar a unique ID.