### PR TITLE
closed warning alert additional invites

### DIFF
--- a/client/src/components/LinkFormModal.tsx
+++ b/client/src/components/LinkFormModal.tsx
@@ -80,8 +80,10 @@ class LinkFormModal extends React.Component<InvitationProps, InvitationState, IA
         this.setState({ [event.target.name]: event.target.value}
         );
         this.setState({
-            invite_sent: false
+            invite_sent: false,
+            submitted: false
         });
+
 
     };
 


### PR DESCRIPTION
closed the alert "... Attempting to send invite." when user attempts to send more invitations before closing alert from previous form submission 